### PR TITLE
Project skeleton hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 # Executables
 *.out
 *.hex
+
+# EEPROM file
+*.eep

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ print_size: main.elf
 
 clean:
 	find . -name '*.[od]' -exec rm -f '{}' \;
-	rm -f *.elf
+	rm -f *.elf *.hex *.eep
 
 # include the generated dependencies
 -include $(OBJS:.o=.d)


### PR DESCRIPTION
Fix makefile not cleaning flash and eeprom images, and gitignore not ignoring eeprom images.